### PR TITLE
fix: fix the import error when running pytest

### DIFF
--- a/python/python/lance_graph/__init__.py
+++ b/python/python/lance_graph/__init__.py
@@ -15,7 +15,10 @@ def _load_bindings() -> ModuleType:
     try:
         from . import _internal as bindings  # type: ignore[attr-defined]
     except ImportError:
-        bindings = _load_dev_build()
+        try:
+            import _internal as bindings  # type: ignore[import-not-found]
+        except ImportError:
+            bindings = _load_dev_build()
     return bindings
 
 


### PR DESCRIPTION
This PR fixs the import error ("ImportError: cannot import name '_internal' from partially initialized module 'lance_graph' (most likely due to a circular import)") when running `pytest` after `maturin develop`.
