### PR TITLE
[chore] Update cargo.lock and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cargo test
 cd python
 uv venv --python 3.11 .venv      # create the local virtualenv
 source .venv/bin/activate         # activate the virtual environment
-uv pip install maturin[patchelf] # install build tool
+uv pip install 'maturin[patchelf]' # install build tool
 uv pip install -e '.[tests]'     # editable install with test extras
 maturin develop                   # build and install the Rust extension
 pytest python/tests/ -v          # run the test suite

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -1871,6 +1871,7 @@ dependencies = [
  "datafusion",
  "datafusion-common",
  "datafusion-expr",
+ "datafusion-functions-aggregate",
  "datafusion-sql",
  "lance-core",
  "nom 7.1.3",


### PR DESCRIPTION
1. the `cargo.lock` was updated by the cargo
2. zsh will fail if no quotation mark