### PR TITLE
feat: Use datafusion planner as the default execution strategy

### DIFF
--- a/python/python/tests/test_graph.py
+++ b/python/python/tests/test_graph.py
@@ -69,18 +69,9 @@ def test_basic_node_selection(graph_env, execute_method):
     result = getattr(query, execute_method)({"Person": datasets["Person"]})
     data = result.to_pydict()
 
-    # TODO: remove this if/else statements when the execute() also returns
-    # Cypher dot notation
-    if execute_method == "execute":
-        # execute() returns unqualified names for simple queries
-        assert set(data.keys()) == {"name", "age"}
-        assert len(data["name"]) == 4
-        assert "Alice" in set(data["name"])
-    else:
-        # execute_datafusion() returns Cypher dot notation
-        assert set(data.keys()) == {"p.name", "p.age"}
-        assert len(data["p.name"]) == 4
-        assert "Alice" in set(data["p.name"])
+    assert set(data.keys()) == {"p.name", "p.age"}
+    assert len(data["p.name"]) == 4
+    assert "Alice" in set(data["p.name"])
 
 
 @pytest.mark.parametrize("execute_method", ["execute", "execute_datafusion"])
@@ -92,14 +83,9 @@ def test_filtered_query(graph_env, execute_method):
     result = getattr(query, execute_method)({"Person": datasets["Person"]})
     data = result.to_pydict()
 
-    if execute_method == "execute":
-        assert len(data["name"]) == 2
-        assert set(data["name"]) == {"Bob", "David"}
-        assert all(age > 30 for age in data["age"])
-    else:
-        assert len(data["p.name"]) == 2
-        assert set(data["p.name"]) == {"Bob", "David"}
-        assert all(age > 30 for age in data["p.age"])
+    assert len(data["p.name"]) == 2
+    assert set(data["p.name"]) == {"Bob", "David"}
+    assert all(age > 30 for age in data["p.age"])
 
 
 @pytest.mark.parametrize("execute_method", ["execute", "execute_datafusion"])
@@ -209,11 +195,5 @@ def test_distinct_clause(graph_env, execute_method):
     )
     data = result.to_pydict()
 
-    if execute_method == "execute":
-        # execute() returns qualified column names for relationship queries
-        assert len(data["c__company_name"]) == 3
-        assert set(data["c__company_name"]) == {"TechCorp", "DataInc", "CloudSoft"}
-    else:
-        # execute_datafusion() returns Cypher dot notation
-        assert len(data["c.company_name"]) == 3
-        assert set(data["c.company_name"]) == {"TechCorp", "DataInc", "CloudSoft"}
+    assert len(data["c.company_name"]) == 3
+    assert set(data["c.company_name"]) == {"TechCorp", "DataInc", "CloudSoft"}

--- a/python/python/tests/test_knowledge_graph_config.py
+++ b/python/python/tests/test_knowledge_graph_config.py
@@ -21,7 +21,7 @@ def test_build_graph_config_from_mapping_supports_simple_nodes():
         .execute({"Person": table})
         .to_pydict()
     )
-    assert data["person_id"] == [1, 2]
+    assert data["id"] == [1, 2]
 
 
 def test_build_graph_config_from_mapping_requires_id_field():

--- a/rust/lance-graph/src/query/simple_executor.rs
+++ b/rust/lance-graph/src/query/simple_executor.rs
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright The Lance Authors
+
+//! Helper functions for simple single-table query execution
+
+/// Minimal translator for simple boolean expressions into DataFusion Expr
+pub(super) fn to_df_boolean_expr_simple(
+    expr: &crate::ast::BooleanExpression,
+) -> Option<datafusion::logical_expr::Expr> {
+    use crate::ast::{BooleanExpression as BE, ComparisonOperator as CO, ValueExpression as VE};
+    use crate::query::expr::to_df_literal;
+    use datafusion::logical_expr::{col, Expr, Operator};
+    match expr {
+        BE::Comparison {
+            left,
+            operator,
+            right,
+        } => {
+            let (col_name, lit_expr) = match (left, right) {
+                (VE::Property(prop), VE::Literal(val)) => {
+                    (prop.property.clone(), to_df_literal(val))
+                }
+                (VE::Literal(val), VE::Property(prop)) => {
+                    (prop.property.clone(), to_df_literal(val))
+                }
+                _ => return None,
+            };
+            let op = match operator {
+                CO::Equal => Operator::Eq,
+                CO::NotEqual => Operator::NotEq,
+                CO::LessThan => Operator::Lt,
+                CO::LessThanOrEqual => Operator::LtEq,
+                CO::GreaterThan => Operator::Gt,
+                CO::GreaterThanOrEqual => Operator::GtEq,
+            };
+            Some(Expr::BinaryExpr(datafusion::logical_expr::BinaryExpr {
+                left: Box::new(col(col_name)),
+                op,
+                right: Box::new(lit_expr),
+            }))
+        }
+        BE::And(l, r) => Some(datafusion::logical_expr::Expr::BinaryExpr(
+            datafusion::logical_expr::BinaryExpr {
+                left: Box::new(to_df_boolean_expr_simple(l)?),
+                op: Operator::And,
+                right: Box::new(to_df_boolean_expr_simple(r)?),
+            },
+        )),
+        BE::Or(l, r) => Some(datafusion::logical_expr::Expr::BinaryExpr(
+            datafusion::logical_expr::BinaryExpr {
+                left: Box::new(to_df_boolean_expr_simple(l)?),
+                op: Operator::Or,
+                right: Box::new(to_df_boolean_expr_simple(r)?),
+            },
+        )),
+        BE::Not(inner) => Some(datafusion::logical_expr::Expr::Not(Box::new(
+            to_df_boolean_expr_simple(inner)?,
+        ))),
+        BE::Exists(prop) => Some(datafusion::logical_expr::Expr::IsNotNull(Box::new(
+            datafusion::logical_expr::Expr::Column(datafusion::common::Column::from_name(
+                prop.property.clone(),
+            )),
+        ))),
+        _ => None,
+    }
+}
+
+/// Build ORDER BY expressions for simple queries
+pub(super) fn to_df_order_by_expr_simple(
+    items: &[crate::ast::OrderByItem],
+) -> Vec<datafusion::logical_expr::SortExpr> {
+    use datafusion::logical_expr::SortExpr;
+    items
+        .iter()
+        .map(|item| {
+            let expr = to_df_value_expr_simple(&item.expression);
+            let asc = matches!(item.direction, crate::ast::SortDirection::Ascending);
+            SortExpr {
+                expr,
+                asc,
+                nulls_first: false,
+            }
+        })
+        .collect()
+}
+
+/// Build value expressions for simple queries
+pub(super) fn to_df_value_expr_simple(
+    expr: &crate::ast::ValueExpression,
+) -> datafusion::logical_expr::Expr {
+    use crate::ast::ValueExpression as VE;
+    use crate::query::expr::to_df_literal;
+    use datafusion::logical_expr::{col, lit};
+    match expr {
+        VE::Property(prop) => col(&prop.property),
+        VE::Variable(v) => col(v),
+        VE::Literal(v) => to_df_literal(v),
+        VE::Function { .. } | VE::Arithmetic { .. } => lit(0),
+    }
+}


### PR DESCRIPTION
This PR
- uses the datafusion planner as the default execution strategy in the `execute` API
- moves the previous implementation of the `execute` to `execute_simple`
- updates the Python api accordingly
- refactors some helper methods of the previous `execute` method to `simple_executor.rs`
- removes dead code in the `qeury.rs`
