### PR TITLE
feat: expose the llm callable in the qa agent

### DIFF
--- a/python/python/knowledge_graph/llm/llm_utils.py
+++ b/python/python/knowledge_graph/llm/llm_utils.py
@@ -37,9 +37,11 @@ def create_llm_client(
     llm_model: str,
     llm_temperature: float,
     llm_options: Optional[Mapping[str, Any]] = None,
+    llm_callable: Optional[Any] = None,
 ) -> kg_extraction.LLMClient:
     resolved_options = dict(llm_options or {})
     return kg_extraction.get_llm_client(
+        llm_callable=llm_callable,
         llm_model=llm_model,
         llm_temperature=llm_temperature,
         llm_options=resolved_options,

--- a/python/python/knowledge_graph/llm/qa.py
+++ b/python/python/knowledge_graph/llm/qa.py
@@ -35,12 +35,14 @@ def ask_question(
     llm_temperature: float,
     llm_config_path,
     embedding_model: str | None,
+    llm_callable=None,
 ) -> str:
     client_options = load_llm_options(llm_config_path)
     llm_client = create_llm_client(
         llm_model=llm_model,
         llm_temperature=llm_temperature,
         llm_options=client_options,
+        llm_callable=llm_callable,
     )
     embedding_generator = resolve_embedding_generator(
         model_name=embedding_model, options=client_options


### PR DESCRIPTION
Similar to the exposition of `llm_callable` in the LLM extractor, this PR exposes the `llm_callable` in the QA agent so users can use other types of LLM clients besides OpenAI.
