### PR TITLE
feat(python): discover actual entity and relationship types from the …

### DIFF
--- a/python/python/knowledge_graph/llm/qa.py
+++ b/python/python/knowledge_graph/llm/qa.py
@@ -319,7 +319,7 @@ def _discover_relationship_types(service: LanceKnowledgeGraph) -> list[str]:
 
     Results are cached on the service object to avoid repeated table loads.
     """
-    if hasattr(service, '_cached_rel_types'):
+    if hasattr(service, "_cached_rel_types"):
         return service._cached_rel_types
 
     try:
@@ -341,7 +341,7 @@ def _discover_entity_types(service: LanceKnowledgeGraph) -> list[str]:
 
     Results are cached on the service object to avoid repeated table loads.
     """
-    if hasattr(service, '_cached_entity_types'):
+    if hasattr(service, "_cached_entity_types"):
         return service._cached_entity_types
 
     try:


### PR DESCRIPTION
…table

Currently, the Python-based knowledge graph's QA component accepts the manually created graph config and the real LLM (or Heuristic) extracted entity and relationship types. The two schemas are not necessarily the same and can cause issues in generating and running Cypher queries. For example, the manually created graph config may use `WORK_AT`, but the LLM extracted relationship type may be `WORK_FOR`.

This PR addresses the issue by always discovering the actual entity and relationship types first (cache is used to improve performance) and leveraging the manually created graph config as a fallback.
