### PR TITLE
feat: implement arithmetic expression computation in DataFusion planner

### DIFF
--- a/rust/lance-graph/src/datafusion_planner/expression.rs
+++ b/rust/lance-graph/src/datafusion_planner/expression.rs
@@ -491,7 +491,10 @@ mod tests {
         // Arithmetic expressions should now return a BinaryExpr with Plus operator
         assert!(s.contains("BinaryExpr"), "Should be a BinaryExpr");
         assert!(s.contains("Plus"), "Should contain Plus operator");
-        assert!(s.contains("p__age"), "Should contain the left operand column");
+        assert!(
+            s.contains("p__age"),
+            "Should contain the left operand column"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Implement proper translation of Cypher arithmetic expressions (+, -, *, /, %) to DataFusion BinaryExpr instead of returning a placeholder lit(0).

Changes:
- Add full arithmetic operator support in to_df_value_expr()
- Map ArithmeticOperator variants to DataFusion Operator equivalents
- Update tests to verify proper BinaryExpr generation with correct operators