### PR TITLE
feature: add ilike support

### DIFF
--- a/rust/lance-graph/src/ast.rs
+++ b/rust/lance-graph/src/ast.rs
@@ -218,8 +218,13 @@ pub enum BooleanExpression {
         expression: ValueExpression,
         list: Vec<ValueExpression>,
     },
-    /// LIKE pattern matching
+    /// LIKE pattern matching (case-sensitive)
     Like {
+        expression: ValueExpression,
+        pattern: String,
+    },
+    /// ILIKE pattern matching (case-insensitive)
+    ILike {
         expression: ValueExpression,
         pattern: String,
     },

--- a/rust/lance-graph/src/semantic.rs
+++ b/rust/lance-graph/src/semantic.rs
@@ -247,6 +247,9 @@ impl SemanticAnalyzer {
             BooleanExpression::Like { expression, .. } => {
                 self.analyze_value_expression(expression)?;
             }
+            BooleanExpression::ILike { expression, .. } => {
+                self.analyze_value_expression(expression)?;
+            }
             BooleanExpression::Contains { expression, .. } => {
                 self.analyze_value_expression(expression)?;
             }


### PR DESCRIPTION
  ---
feat: add ILIKE case-insensitive pattern matching

  Implements ILIKE operator that works like LIKE but ignores case.
  Leverages DataFusion's case_insensitive flag on Like expressions.