### PR TITLE
feat: add toLower/toUpper support, fix type coercion error

### DIFF
--- a/rust/lance-graph/src/datafusion_planner/expression.rs
+++ b/rust/lance-graph/src/datafusion_planner/expression.rs
@@ -7,9 +7,9 @@
 
 use crate::ast::{BooleanExpression, PropertyValue, ValueExpression};
 use crate::datafusion_planner::udf;
-use datafusion::logical_expr::{col, lit, BinaryExpr, Expr, Operator};
 use datafusion::functions::string::lower;
 use datafusion::functions::string::upper;
+use datafusion::logical_expr::{col, lit, BinaryExpr, Expr, Operator};
 use datafusion_functions_aggregate::average::avg;
 use datafusion_functions_aggregate::count::count;
 use datafusion_functions_aggregate::min_max::max;

--- a/rust/lance-graph/tests/test_datafusion_pipeline.rs
+++ b/rust/lance-graph/tests/test_datafusion_pipeline.rs
@@ -4155,11 +4155,10 @@ async fn test_toupper_with_contains() {
     let person_batch = create_person_dataset();
 
     // Search for names containing 'BOB' (case-insensitive via toUpper)
-    let query = CypherQuery::new(
-        "MATCH (p:Person) WHERE toUpper(p.name) CONTAINS 'BOB' RETURN p.name",
-    )
-    .unwrap()
-    .with_config(config);
+    let query =
+        CypherQuery::new("MATCH (p:Person) WHERE toUpper(p.name) CONTAINS 'BOB' RETURN p.name")
+            .unwrap()
+            .with_config(config);
 
     let mut datasets = HashMap::new();
     datasets.insert("Person".to_string(), person_batch);


### PR DESCRIPTION
## Summary
- Add support for `toLower`/`toUpper` (Cypher) and `lower`/`upper` (SQL) string functions
- Change fallback for unsupported functions from `lit(0)` to `ScalarValue::Null` to prevent type coercion errors

## Problem
When using `toLower(s.name) CONTAINS 'x'` with integer columns in the RETURN clause, a type coercion error occurred:
```
type_coercion: There isn't a common type to coerce Int32 and Utf8 in LIKE expression
```

This happened because `toLower` was not implemented and fell through to the default case which returned `lit(0)` (Int32). When combined with `CONTAINS` (translated to LIKE), DataFusion couldn't coerce Int32 to Utf8.

## Solution
1. Implemented `toLower`/`toUpper` using DataFusion's `lower()`/`upper()` functions
2. Changed the fallback for unsupported functions from `lit(0)` to `ScalarValue::Null`, which coerces to any type in SQL semantics

## Test plan
- [x] Added unit tests for `toLower`, `toUpper`, `lower`, `upper` functions
- [x] Added integration test reproducing the exact bug scenario
- [x] All 196 existing tests pass