### PR TITLE
feat(graph): add WITH clause with query chaining support

### DIFF
--- a/rust/lance-graph/src/ast.rs
+++ b/rust/lance-graph/src/ast.rs
@@ -15,8 +15,14 @@ use std::collections::HashMap;
 pub struct CypherQuery {
     /// MATCH clauses
     pub match_clauses: Vec<MatchClause>,
-    /// WHERE clause (optional)
+    /// WHERE clause (optional, before WITH if present)
     pub where_clause: Option<WhereClause>,
+    /// WITH clause (optional) - intermediate projection/aggregation
+    pub with_clause: Option<WithClause>,
+    /// MATCH clauses after WITH (optional) - query chaining
+    pub post_with_match_clauses: Vec<MatchClause>,
+    /// WHERE clause after WITH (optional) - filters the WITH results
+    pub post_with_where_clause: Option<WhereClause>,
     /// RETURN clause
     pub return_clause: ReturnClause,
     /// LIMIT clause (optional)
@@ -321,6 +327,20 @@ pub enum ArithmeticOperator {
     Multiply,
     Divide,
     Modulo,
+}
+
+/// WITH clause for intermediate projections/aggregations
+///
+/// WITH acts as a query stage boundary, projecting results that become
+/// the input for subsequent clauses.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct WithClause {
+    /// Items to project (similar to RETURN)
+    pub items: Vec<ReturnItem>,
+    /// Optional ORDER BY within WITH
+    pub order_by: Option<OrderByClause>,
+    /// Optional LIMIT within WITH
+    pub limit: Option<u64>,
 }
 
 /// RETURN clause specifying what to return

--- a/rust/lance-graph/src/query.rs
+++ b/rust/lance-graph/src/query.rs
@@ -1178,6 +1178,9 @@ impl CypherQueryBuilder {
             where_clause: self
                 .where_expression
                 .map(|expr| crate::ast::WhereClause { expression: expr }),
+            with_clause: None, // WITH not supported via builder yet
+            post_with_match_clauses: vec![],
+            post_with_where_clause: None,
             return_clause: crate::ast::ReturnClause {
                 distinct: self.distinct,
                 items: self.return_items,


### PR DESCRIPTION
Adds WITH clause for intermediate projections, aggregations, and query chaining in Cypher queries.

Supported syntax:
- WITH projection: WITH p.name AS name
- WITH aggregation: WITH city, count(*) AS total
- WITH ORDER BY/LIMIT: WITH p ORDER BY p.age DESC LIMIT 10
- Post-WITH WHERE: WITH ... WHERE total > 1
- Post-WITH MATCH: WITH ... MATCH (p2:Person) ...

Changes:
- Add WithClause to AST with items, order_by, limit fields
- Add with_clause, post_with_match_clauses, post_with_where_clause to CypherQuery
- Parse WITH clause and post-WITH MATCH/WHERE in parser
- Add semantic analysis for WITH scope
- Add plan_with_clause in logical planner
- Chain post-WITH MATCH using plan_match_clause_with_base
- Add 5 comprehensive tests for WITH functionality

Note: WITH p (passing whole node) then MATCH (p)-[]->(f) requires explicit property projection. Use WITH p.id AS id ... instead.