### PR TITLE
feat: support COUNT(DISTINCT expr) in Cypher queries

### DIFF
--- a/crates/lance-graph/src/datafusion_planner/builder/aggregate_ops.rs
+++ b/crates/lance-graph/src/datafusion_planner/builder/aggregate_ops.rs
@@ -88,9 +88,10 @@ mod tests {
         let project = LogicalOperator::Project {
             input: Box::new(scan),
             projections: vec![ProjectionItem {
-                expression: ValueExpression::Function {
+                expression: ValueExpression::AggregateFunction {
                     name: "count".to_string(),
                     args: vec![ValueExpression::Variable("*".to_string())],
+                    distinct: false,
                 },
                 alias: Some("total".to_string()),
             }],
@@ -114,9 +115,10 @@ mod tests {
         let project = LogicalOperator::Project {
             input: Box::new(scan),
             projections: vec![ProjectionItem {
-                expression: ValueExpression::Function {
+                expression: ValueExpression::AggregateFunction {
                     name: "count".to_string(),
                     args: vec![ValueExpression::Variable("*".to_string())],
+                    distinct: false,
                 },
                 alias: None,
             }],


### PR DESCRIPTION
This PR:

  - Adds support for COUNT(DISTINCT x) aggregation in Cypher queries
  - Introduces proper AST distinction between scalar and aggregate functions (similar to the handling in DataFusion)
  - Validates COUNT(DISTINCT *) is rejected with a helpful error message

Fix https://github.com/lance-format/lance-graph/issues/108

Example:
```cypher
MATCH (p:Person)-[:workAt]->(o:Organisation)
RETURN COUNT(DISTINCT p.id) AS num_employees, o.id
ORDER BY num_employees DESC
```